### PR TITLE
修复项目启动报错问题

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-  presets: [
-    '@vue/app'
-  ]
+  presets: [[
+    '@vue/app',
+    { useBuiltIns: "entry" }
+  ]]
 }


### PR DESCRIPTION
修复项目编译时Can't resolve 'core-js/modules/es6.array.find'问题，原因为core.js版本高于3.x